### PR TITLE
171-prevent-self-admin-change

### DIFF
--- a/BE/api/users.js
+++ b/BE/api/users.js
@@ -178,10 +178,6 @@ usersRouter.patch("/:userId/", requireAdmin, async (req, res, next) => {
 
     delete fields.base64;
 
-    console.log("admin field:", fields.admin);
-    console.log("id of token:", tokenId);
-    console.log("id of param", id);
-
     if(fields.admin && (tokenId == id)){
       delete fields.admin;
       next({
@@ -189,7 +185,6 @@ usersRouter.patch("/:userId/", requireAdmin, async (req, res, next) => {
         message: "You cannot change your own admin status, even as an admin.",
       });
     } else {
-      console.log(fields);
       const updatedUser = await updateUser(id, fields);
       res.send(updatedUser);
     }


### PR DESCRIPTION
Prevents admin from changing their own admin status through the /:userId patch. We already did this for regular users with the /me patch, but not yet /:userId for admin